### PR TITLE
Fix syntax errors in three mjk-examples files

### DIFF
--- a/mjk-examples/CAP/odmobject-motion-sensor.sdf.json
+++ b/mjk-examples/CAP/odmobject-motion-sensor.sdf.json
@@ -22,9 +22,7 @@
       }, 
       "odmEvent": {
         "stateChange": { 
-          "odmOutputData" : { 
-            "odmRef": "#/odmData/activityState"
-          }
+          "odmOutputData" : [ "#/odmData/activityState"]
         }
       }
     }

--- a/mjk-examples/CAP/odmobject-oven-operating-state.sdf.json
+++ b/mjk-examples/CAP/odmobject-oven-operating-state.sdf.json
@@ -26,6 +26,7 @@
           "type": "array",
           "items": {
             "enum": [ "ready", "running", "paused" ]
+          }
         },
         "ovenJobState": {
           "type": "string",

--- a/mjk-examples/ZCL/odmobject-onoff-v7.sdf.json
+++ b/mjk-examples/ZCL/odmobject-onoff-v7.sdf.json
@@ -42,6 +42,7 @@
         "StartUpOnOff": {
           "odmRef": "#/odmData/StartUpOnOffMode", 
           "label": "StartUpOnOff"
+        }
       }, 
       "odmAction": {
         "Off": {
@@ -84,7 +85,7 @@
           }
         },
         "OnWithRecallGlobalScene": {
-          "label": "OnWithRecallGlobalScene", 
+          "label": "OnWithRecallGlobalScene"
         }, 
         "OnWithTimedOff": {
           "label": "OnWithTimedOff", 


### PR DESCRIPTION
To do:
File name odmobject-ovenModeData.sdf.json does not match ^odm(object|thing|data)-[a-z0-9_.-]*.sdf.json$
type=number, subtype=float -- mjk-examples/IPSO/odmthing-ipso3300.sdf.json
".odmObject['Level'].odmProperty['Options'].default" -- mjk-examples/ZCL/odmobject-level-v7.sdf.json'