### PR TITLE
Move CI from Travis to Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run CI script
+        run: ./run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-script: ./run.sh

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ The models here are intended as experimental submissions that indeed potentially
 They are not commitments by the submitting entity that they are going to be exactly the way forward.
 Note that there is another repository, "exploratory", that can be used for exploring new SDF features or new model translation design patterns.
 
-Experimental CI: [![Build Status](https://travis-ci.org/one-data-model/playground.svg?branch=master
-)](https://travis-ci.org/one-data-model/playground) — please check the
-Travis build log linked through this badge for CI messages.
+Experimental CI: [![CI](https://github.com/one-data-model/playground/actions/workflows/ci.yml/badge.svg
+)](https://github.com/one-data-model/playground/actions/workflows/ci.yml) — please check the
+build log linked through this badge for CI messages.


### PR DESCRIPTION
This PR replaces the existing Travis CI workflow with one that is run by Github Actions.