### PR TITLE
replace boolean `exclusiveMinimum`s

### DIFF
--- a/sdfObject/sdfobject-calorificvalue.sdf.json
+++ b/sdfObject/sdfobject-calorificvalue.sdf.json
@@ -22,8 +22,7 @@
           "description": "Calorific value of fuel",
           "writable": false,
           "type": "number",
-          "minimum": 0,
-          "exclusiveMinimum": true
+          "exclusiveMinimum": 0
         }
       },
       "sdfRequired": [

--- a/sdfObject/sdfobject-conversionfactor.sdf.json
+++ b/sdfObject/sdfobject-conversionfactor.sdf.json
@@ -17,8 +17,7 @@
           "description": "Conversion factor to convert a volume of a fuel to energy consumption",
           "writable": false,
           "type": "number",
-          "minimum": 0,
-          "exclusiveMinimum": true
+          "exclusiveMinimum": 0
         },
         "precision": {
           "description": "Accuracy granularity of the exposed value",

--- a/sdfObject/sdfobject-hvac_capacity.sdf.json
+++ b/sdfObject/sdfobject-hvac_capacity.sdf.json
@@ -15,8 +15,7 @@
       "sdfProperty": {
         "capacity": {
           "description": "The rated capacity for the Device.",
-          "minimum": 0,
-          "exclusiveMinimum": true,
+          "exclusiveMinimum": 0,
           "writable": false,
           "type": "number"
         }


### PR DESCRIPTION
Corresponding with https://github.com/ietf-wg-asdf/SDF/pull/86, there are currently a few models in the playground that are not specification-compliant anymore, as they use the old boolean format for describing an `exclusiveMinimum`. As I have already updated the logic in my WoT converter, this led to failures in [three cases](https://github.com/JKRhb/onedm-playground-wot-tm/commit/ae23750dbb06d488b42c0082d30a641d5e07cd45) during the automatic conversion from SDF to WoT Thing Models.

This PR provides a simple fix for the problem by replacing the boolean `exclusiveMinimum` fields with numeric alternatives.


