### PR TITLE
IPSO Temperature Object using sdfChoice and OMA IDs

### DIFF
--- a/sdfObject/sdfobject-ipso-temperature-sdfchoice.sdf.json
+++ b/sdfObject/sdfobject-ipso-temperature-sdfchoice.sdf.json
@@ -92,34 +92,34 @@
           "sdfChoice": {
             "UNCHECKED": {
               "description": "No quality checks were done because they do not exist or can not be applied.",
-              "const": "0"
+              "const": 0
             },
             "REJECTED WITH CERTAINTY": {
               "description": "The measured value is invalid.",
-              "const": "1"
+              "const": 1
             },
             "REJECTED WITH PROBABILITY": {
               "description": "The measured value is likely invalid.",
-              "const": "2"
+              "const": 2
             },
             "ACCEPTED BUT SUSPICIOUS": {
               "description": "The measured value is likely OK.",
-              "const": "3"
+              "const": 3
             },
             "ACCEPTED": {
               "description": "The measured value is OK.",
-              "const": "4"
+              "const": 4
             },
             "option6": {
               "description": "Reserved for future extensions.",
-              "minimum": "5",
-              "maximum": "15",
+              "minimum": 5,
+              "maximum": 15,
               "type": "integer"
             },
             "option7": {
               "description": "Vendor specific measurement quality.",
-              "minimum": "16",
-              "maximum": "23",
+              "minimum": 16,
+              "maximum": 23,
               "type": "integer"
             }
           }

--- a/sdfObject/sdfobject-ipso-temperature-sdfchoice.sdf.json
+++ b/sdfObject/sdfobject-ipso-temperature-sdfchoice.sdf.json
@@ -1,0 +1,149 @@
+{
+  "info": {
+    "title": "OMA LwM2M Temperature (Object ID 3303)",
+    "version": "2023-03-25",
+    "copyright": "Copyright 2019 Open Mobile Alliance.",
+    "license": "BSD-3-Clause"
+  },
+  "namespace": {
+    "oma": "https://onedm.org/ecosystem/oma"
+  },
+  "defaultNamespace": "oma",
+  "sdfObject": {
+    "Temperature": {
+      "label": "Temperature",
+      "description": "This IPSO object should be used with a temperature sensor to report a temperature measurement.  It also provides resources for minimum/maximum measured values and the minimum/maximum range that can be measured by the temperature sensor. An example measurement unit is degrees Celsius.",
+      "oma:id": "3303",
+      "sdfProperty": {
+        "Sensor_Value": {
+          "label": "Sensor Value",
+          "description": "Last or Current Measured Value from the Sensor.",
+          "oma:id": 5700,
+          "writable": false,
+          "type": "number"
+        },
+        "Min_Measured_Value": {
+          "label": "Min Measured Value",
+          "description": "The minimum value measured by the sensor since power ON or reset.",
+          "oma:id": 5601,
+          "writable": false,
+          "type": "number"
+        },
+        "Max_Measured_Value": {
+          "label": "Max Measured Value",
+          "description": "The maximum value measured by the sensor since power ON or reset.",
+          "oma:id": 5602,
+          "writable": false,
+          "type": "number"
+        },
+        "Min_Range_Value": {
+          "label": "Min Range Value",
+          "description": "The minimum value that can be measured by the sensor.",
+          "oma:id": 5603,
+          "writable": false,
+          "type": "number"
+        },
+        "Max_Range_Value": {
+          "label": "Max Range Value",
+          "description": "The maximum value that can be measured by the sensor.",
+          "oma:id": 5604,
+          "writable": false,
+          "type": "number"
+        },
+        "Sensor_Units": {
+          "label": "Sensor Units",
+          "description": "Measurement Units Definition.",
+          "oma:id": 5701,
+          "writable": false,
+          "type": "string"
+        },
+        "Application_Type": {
+          "label": "Application Type",
+          "description": "The application type of the sensor or actuator as a string depending on the use case.",
+          "oma:id": 5750,
+          "type": "string"
+        },
+        "Timestamp": {
+          "label": "Timestamp",
+          "description": "The timestamp of when the measurement was performed.",
+          "oma:id": 5518,
+          "writable": false,
+          "type": "number",
+          "sdfType": "unix-time"
+        },
+        "Fractional_Timestamp": {
+          "label": "Fractional Timestamp",
+          "description": "Fractional part of the timestamp when sub-second precision is used (e.g., 0.23 for 230 ms).",
+          "oma:id": 6050,
+          "writable": false,
+          "type": "number",
+          "unit": "s",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "Measurement_Quality_Indicator": {
+          "label": "Measurement Quality Indicator",
+          "description": "Measurement quality indicator reported by a smart sensor.",
+          "oma:id": 6042,
+          "writable": false,
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 23,
+          "sdfChoice": {
+            "UNCHECKED": {
+              "description": "No quality checks were done because they do not exist or can not be applied.",
+              "const": "0"
+            },
+            "REJECTED WITH CERTAINTY": {
+              "description": "The measured value is invalid.",
+              "const": "1"
+            },
+            "REJECTED WITH PROBABILITY": {
+              "description": "The measured value is likely invalid.",
+              "const": "2"
+            },
+            "ACCEPTED BUT SUSPICIOUS": {
+              "description": "The measured value is likely OK.",
+              "const": "3"
+            },
+            "ACCEPTED": {
+              "description": "The measured value is OK.",
+              "const": "4"
+            },
+            "option6": {
+              "description": "Reserved for future extensions.",
+              "minimum": "5",
+              "maximum": "15",
+              "type": "integer"
+            },
+            "option7": {
+              "description": "Vendor specific measurement quality.",
+              "minimum": "16",
+              "maximum": "23",
+              "type": "integer"
+            }
+          }
+        },
+        "Measurement_Quality_Level": {
+          "label": "Measurement Quality Level",
+          "description": "Measurement quality level reported by a smart sensor. Quality level 100 means that the measurement has fully passed quality check algorithms. Smaller quality levels mean that quality has decreased and the measurement has only partially passed quality check algorithms. The smaller the quality level, the more caution should be used by the application when using the measurement. When the quality level is 0 it means that the measurement should certainly be rejected.",
+          "oma:id": 6049,
+          "writable": false,
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      },
+      "sdfAction": {
+        "Reset_Min_and_Max_Measured_Values": {
+          "label": "Reset Min and Max Measured Values",
+          "description": "Reset the Min and Max Measured Values to Current Value.",
+          "oma:id": 5605
+        }
+      },
+      "sdfRequired": [
+        "#/sdfObject/Temperature/sdfProperty/Sensor_Value"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Measurement_Quality_Indicator resource uses sdfChoice parsed from the description. All definitions also contain Object/Resource IDs. 